### PR TITLE
Add getList endpoint

### DIFF
--- a/src/emailOctopus.ts
+++ b/src/emailOctopus.ts
@@ -6,6 +6,7 @@ import { NotFoundError } from "./errors/NotFoundError";
 import { UnauthorisedError } from "./errors/UnauthorisedError";
 import { createContact } from "./lists/createContact";
 import { getAllContacts } from "./lists/getAllContacts";
+import { getList } from "./lists/getList";
 
 export {
   ApiKeyInvalidError,
@@ -19,6 +20,7 @@ export {
 export const emailOctopus = (apiKey: string) => {
   return {
     lists: {
+      getList: getList(apiKey),
       getAllContacts: getAllContacts(apiKey),
       createContact: createContact(apiKey),
     },

--- a/src/errors/ListNotFoundError.ts
+++ b/src/errors/ListNotFoundError.ts
@@ -1,0 +1,11 @@
+export class ListNotFoundError extends Error {
+  code = "LIST_NOT_FOUND";
+  message: string = "The list could not be found.";
+
+  constructor(message?: string) {
+    super(message || "The list could not be found.");
+
+    this.message = message || "The list could not be found.";
+    this.name = "ListNotFoundError";
+  }
+}

--- a/src/errors/UnknownError.ts
+++ b/src/errors/UnknownError.ts
@@ -1,0 +1,11 @@
+export class UnknownError extends Error {
+  code = "UNKNOWN";
+  message: string = "An unknown error has occurred.";
+
+  constructor(message?: string) {
+    super(message || "An unknown error has occurred.");
+
+    this.message = message || "An unknown error has occurred.";
+    this.name = "UnknownError";
+  }
+}

--- a/src/handlers/apiGlobalErrorHandler.ts
+++ b/src/handlers/apiGlobalErrorHandler.ts
@@ -3,6 +3,7 @@ import { ApiKeyInvalidError } from "src/errors/ApiKeyInvalidError";
 import { InvalidParametersError } from "src/errors/InvalidParametersError";
 import { NotFoundError } from "src/errors/NotFoundError";
 import { UnauthorisedError } from "src/errors/UnauthorisedError";
+import { UnknownError } from "src/errors/UnknownError";
 import { ApiWideErrorResponses } from "src/types";
 
 export const handleApiGlobalErrors = (
@@ -20,5 +21,8 @@ export const handleApiGlobalErrors = (
   }
   if (error.code === "NOT_FOUND") {
     throw new NotFoundError(errorData.message);
+  }
+  if (error.code === "UNKNOWN") {
+    throw new UnknownError(errorData.message);
   }
 };

--- a/src/lists/getList.ts
+++ b/src/lists/getList.ts
@@ -1,0 +1,61 @@
+import axios from "axios";
+import { EmailOctopusError } from "src/errors/EmailOctopusError";
+import { ListNotFoundError } from "src/errors/ListNotFoundError";
+import { handleApiGlobalErrors } from "src/handlers/apiGlobalErrorHandler";
+import { ApiWideErrorResponses } from "src/types";
+
+type GetListProps = {
+  listId: string;
+};
+
+type Field = {
+  tag: string;
+  type: string;
+  label: string;
+  fallback: string;
+};
+
+type Counts = {
+  pending: number;
+  subscribed: number;
+  unsubscribed: number;
+};
+
+type List = {
+  id: string;
+  name: string;
+  double_opt_in: boolean;
+  fields: Array<Field>;
+  counts: Counts;
+  created_at: string;
+};
+
+type GetListErrorListNotFound = {
+  code: "LIST_NOT_FOUND";
+  message: string;
+};
+
+export const getList =
+  (apiKey: string) =>
+  async (props: GetListProps): Promise<List> => {
+    try {
+      const response = await axios.post<List>(
+        `https://emailoctopus.com/api/1.6/lists/${props.listId}`,
+        {
+          api_key: apiKey,
+        },
+      );
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        const errorData = error.response?.data as
+          | ApiWideErrorResponses
+          | GetListErrorListNotFound;
+        if (errorData.code === "LIST_NOT_FOUND") {
+          throw new ListNotFoundError();
+        }
+        handleApiGlobalErrors(error, errorData);
+      }
+      throw new EmailOctopusError();
+    }
+  };


### PR DESCRIPTION
Based on the documentation: https://emailoctopus.com/api-documentation/lists/get

Added that endpoint to the package.

Can now be used like:

```ts
import { emailOctopus } from "email-octopus-ts";

// TODO: Replace the API key.
const emailOctopusApiKey = "...";
const EmailOctopus = emailOctopus(emailOctopusApiKey);

const list = await EmailOctopus.lists.getList({
  listId: "...",
});

console.log(list.id);
```