### PR TITLE
refactor/changes apiGlobalErrorHandler naming 

### DIFF
--- a/src/handlers/apiGlobalAxiosErrorHandler.ts
+++ b/src/handlers/apiGlobalAxiosErrorHandler.ts
@@ -8,7 +8,7 @@ import {
 import { UnknownError } from "../errors/UnknownError";
 import { ApiWideErrorResponses } from "../types";
 
-export const handleApiGlobalErrors = (
+export const handleApiGlobalAxiosErrors = (
   error: AxiosError,
   errorData: ApiWideErrorResponses,
 ): void => {

--- a/src/lists/createContact.ts
+++ b/src/lists/createContact.ts
@@ -3,7 +3,7 @@ import {
   MemberExistsWithEmailAddressError,
   EmailOctopusError,
 } from "../emailOctopus";
-import { handleApiGlobalErrors } from "../handlers/apiGlobalErrorHandler";
+import { handleApiGlobalAxiosErrors } from "../handlers/apiGlobalAxiosErrorHandler";
 import { Contact, ApiWideErrorResponses } from "../types";
 
 export type CreateContactProps = {
@@ -43,7 +43,7 @@ export const createContact =
         if (errorData.code === "MEMBER_EXISTS_WITH_EMAIL_ADDRESS") {
           throw new MemberExistsWithEmailAddressError();
         }
-        handleApiGlobalErrors(error, errorData);
+        handleApiGlobalAxiosErrors(error, errorData);
       }
       throw new EmailOctopusError();
     }

--- a/src/lists/createList.ts
+++ b/src/lists/createList.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { List } from "./types";
 import { EmailOctopusError } from "../emailOctopus";
-import { handleApiGlobalErrors } from "../handlers/apiGlobalErrorHandler";
+import { handleApiGlobalAxiosErrors } from "../handlers/apiGlobalAxiosErrorHandler";
 import { ApiWideErrorResponses } from "../types";
 
 type CreateListProps = {
@@ -23,7 +23,7 @@ export const createList =
     } catch (error) {
       if (axios.isAxiosError(error) && error.response) {
         const errorData = error.response?.data as ApiWideErrorResponses;
-        handleApiGlobalErrors(error, errorData);
+        handleApiGlobalAxiosErrors(error, errorData);
       }
       throw new EmailOctopusError();
     }

--- a/src/lists/getAllContacts.ts
+++ b/src/lists/getAllContacts.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { EmailOctopusError } from "../errors/EmailOctopusError";
 import { Paging } from "./types";
-import { handleApiGlobalErrors } from "../handlers/apiGlobalErrorHandler";
+import { handleApiGlobalAxiosErrors } from "../handlers/apiGlobalAxiosErrorHandler";
 import { Contact, ApiWideErrorResponses } from "../types";
 
 type GetAllContactsProps = {
@@ -53,7 +53,7 @@ export const getAllContacts =
     } catch (error) {
       if (axios.isAxiosError(error) && error.response) {
         const errorData = error.response?.data as ApiWideErrorResponses;
-        handleApiGlobalErrors(error, errorData);
+        handleApiGlobalAxiosErrors(error, errorData);
       }
       throw new EmailOctopusError();
     }

--- a/src/lists/getAllLists.ts
+++ b/src/lists/getAllLists.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { List, Paging } from "./types";
 import { EmailOctopusError } from "../emailOctopus";
-import { handleApiGlobalErrors } from "../handlers/apiGlobalErrorHandler";
+import { handleApiGlobalAxiosErrors } from "../handlers/apiGlobalAxiosErrorHandler";
 import { ApiWideErrorResponses } from "../types";
 
 type GetAllListProps = {
@@ -33,7 +33,7 @@ export const getAllLists =
       if (axios.isAxiosError(error) && error.response) {
         const errorData = error.response?.data as ApiWideErrorResponses;
 
-        handleApiGlobalErrors(error, errorData);
+        handleApiGlobalAxiosErrors(error, errorData);
       }
       throw new EmailOctopusError();
     }

--- a/src/lists/getList.ts
+++ b/src/lists/getList.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { List } from "./types";
 import { EmailOctopusError } from "../emailOctopus";
 import { ListNotFoundError } from "../errors/ListNotFoundError";
-import { handleApiGlobalErrors } from "../handlers/apiGlobalErrorHandler";
+import { handleApiGlobalAxiosErrors } from "../handlers/apiGlobalAxiosErrorHandler";
 import { ApiWideErrorResponses } from "../types";
 
 type GetListProps = {
@@ -35,7 +35,7 @@ export const getList =
         if (errorData.code === "LIST_NOT_FOUND") {
           throw new ListNotFoundError();
         }
-        handleApiGlobalErrors(error, errorData);
+        handleApiGlobalAxiosErrors(error, errorData);
       }
       throw new EmailOctopusError();
     }


### PR DESCRIPTION
Implementation for the issue - #97
I have done code refactoring to change the `apiGlobalErrorHandler` to `apiGlobalAxiosErrorHandler` and all the files that uses this handler.

If everything is ok, add the `hacktoberfest-accepted` label to this pull request, as I am participating in the event and it will help me a lot.
Thank you very much