### PR TITLE
test(#98): ✅ Add cases success and error to createList http post

### DIFF
--- a/src/lists/createList.test.ts
+++ b/src/lists/createList.test.ts
@@ -1,0 +1,44 @@
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { createList } from "./createList";
+import { List } from "./types";
+import { EmailOctopusError } from "../emailOctopus";
+import { ApiWideErrorResponses } from "../types";
+
+const mockAxios = new AxiosMockAdapter(axios);
+
+describe('CreateList', () => {
+    const FAKE_API_KEY = "1c2b40da-5fa3-11ee-8c99-0242ac120002";
+    const input = { name: 'Lorem ipsun' };
+
+    it('should return success and status 200', async () => {
+        const output: List = {} as List;
+
+        mockAxios.onPost().replyOnce(200, output);
+        jest.spyOn(axios, "post");
+
+        const result = await createList(FAKE_API_KEY)(input);
+
+        expect(result).toEqual(output);
+        expect(axios.post).toBeCalledWith(
+            'https://emailoctopus.com/api/1.6/lists',
+            { api_key: FAKE_API_KEY, name: 'Lorem ipsun' }
+        );
+    });
+
+    it('should throw EmailOctopusError', async () => {
+        const output = {
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Unexpected Error",
+        };
+
+        mockAxios.onPost().replyOnce(404, output);
+        jest.spyOn(axios, "post");
+
+        const result = await createList(FAKE_API_KEY)(input).catch(
+            (error) => error,
+        );
+
+        expect(result).toBeInstanceOf(EmailOctopusError);
+    });
+});

--- a/src/lists/createList.test.ts
+++ b/src/lists/createList.test.ts
@@ -3,36 +3,43 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import { createList } from "./createList";
 import { List } from "./types";
 import { EmailOctopusError } from "../emailOctopus";
-import { ApiWideErrorResponses } from "../types";
 
 const mockAxios = new AxiosMockAdapter(axios);
 
-describe('CreateList', () => {
+describe('createList', () => {
     const FAKE_API_KEY = "1c2b40da-5fa3-11ee-8c99-0242ac120002";
     const input = { name: 'Lorem ipsun' };
 
-    it('should return success and status 200', async () => {
-        const output: List = {} as List;
-
-        mockAxios.onPost().replyOnce(200, output);
+    it('should successful request', async () => {
+        mockAxios.onPost().replyOnce(200);
         jest.spyOn(axios, "post");
 
-        const result = await createList(FAKE_API_KEY)(input);
+        await createList(FAKE_API_KEY)(input);
 
-        expect(result).toEqual(output);
         expect(axios.post).toBeCalledWith(
             'https://emailoctopus.com/api/1.6/lists',
             { api_key: FAKE_API_KEY, name: 'Lorem ipsun' }
         );
     });
 
-    it('should throw EmailOctopusError', async () => {
+    it('should return a List and status code 201', async () => {
+        const output: List = {} as List;
+
+        mockAxios.onPost().replyOnce(201, output);
+        jest.spyOn(axios, "post");
+
+        const result = await createList(FAKE_API_KEY)(input);
+
+        expect(result).toEqual(output);
+    });
+
+    it('should throw EmailOctopusError to unmaped type error', async () => {
         const output = {
-            code: "INTERNAL_SERVER_ERROR",
+            code: undefined,
             message: "Unexpected Error",
         };
 
-        mockAxios.onPost().replyOnce(404, output);
+        mockAxios.onPost().replyOnce(500, output);
         jest.spyOn(axios, "post");
 
         const result = await createList(FAKE_API_KEY)(input).catch(
@@ -41,4 +48,16 @@ describe('CreateList', () => {
 
         expect(result).toBeInstanceOf(EmailOctopusError);
     });
+
+    it('should throw TypeError to no content response', async () => {
+        mockAxios.onPost().replyOnce(500);
+        jest.spyOn(axios, "post");
+
+        const result = await createList(FAKE_API_KEY)(input).catch(
+            (error) => error,
+        );
+
+        expect(result).toBeInstanceOf(TypeError);
+    });
+
 });


### PR DESCRIPTION
Introduce check success onPost to createList
Introduce check throw EmailOctopusError onPost to createList

![image](https://github.com/kartoffelkraft/email-octopus-ts/assets/44546680/ac7b8a8b-8dde-43e3-98a8-01c2b80fd391)
